### PR TITLE
Update basic agent setup modelCapacity to 60

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "17632891943305566295"
+      "templateHash": "4014231069982867265"
     }
   },
   "parameters": {
@@ -105,7 +105,7 @@
     },
     "modelCapacity": {
       "type": "int",
-      "defaultValue": 40,
+      "defaultValue": 50,
       "metadata": {
         "description": "The capacity of the model deployment in TPM."
       }

--- a/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "4014231069982867265"
+      "templateHash": "12287756194416238896"
     }
   },
   "parameters": {
@@ -105,7 +105,7 @@
     },
     "modelCapacity": {
       "type": "int",
-      "defaultValue": 50,
+      "defaultValue": 60,
       "metadata": {
         "description": "The capacity of the model deployment in TPM."
       }

--- a/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/main.bicep
@@ -59,7 +59,7 @@ param modelVersion string = '2025-04-14'
 param modelSkuName string = 'GlobalStandard'
 
 @description('The capacity of the model deployment in TPM.')
-param modelCapacity int = 50
+param modelCapacity int = 60
 
 resource account 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
   name: accountName

--- a/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/main.bicep
@@ -59,7 +59,7 @@ param modelVersion string = '2025-04-14'
 param modelSkuName string = 'GlobalStandard'
 
 @description('The capacity of the model deployment in TPM.')
-param modelCapacity int = 40
+param modelCapacity int = 50
 
 resource account 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
   name: accountName

--- a/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "4258565578737893898"
+      "templateHash": "32438334008742502"
     }
   },
   "parameters": {
@@ -101,7 +101,7 @@
     },
     "modelCapacity": {
       "type": "int",
-      "defaultValue": 30,
+      "defaultValue": 50,
       "metadata": {
         "description": "The tokens per minute (TPM) of your model deployment"
       }

--- a/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "17836798406056740836"
+      "templateHash": "4258565578737893898"
     }
   },
   "parameters": {
@@ -101,7 +101,7 @@
     },
     "modelCapacity": {
       "type": "int",
-      "defaultValue": 40,
+      "defaultValue": 30,
       "metadata": {
         "description": "The tokens per minute (TPM) of your model deployment"
       }

--- a/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/main.bicep
@@ -56,7 +56,7 @@ param modelVersion string = '2025-04-14'
 param modelSkuName string = 'GlobalStandard'
 
 @description('The tokens per minute (TPM) of your model deployment')
-param modelCapacity int = 40
+param modelCapacity int = 30
 
 // Optionally bring existing resources
 @description('The AI Search Service full ARM Resource ID. This is an optional field, and if not provided, the resource will be created.')

--- a/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/main.bicep
@@ -56,7 +56,7 @@ param modelVersion string = '2025-04-14'
 param modelSkuName string = 'GlobalStandard'
 
 @description('The tokens per minute (TPM) of your model deployment')
-param modelCapacity int = 30
+param modelCapacity int = 50
 
 // Optionally bring existing resources
 @description('The AI Search Service full ARM Resource ID. This is an optional field, and if not provided, the resource will be created.')


### PR DESCRIPTION
Updates the basic agent setup template default `modelCapacity` from 50 to 60.