### PR TITLE
Basic agent setup: set modelQuota to 100

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.39.26.7824",
-      "templateHash": "17632891943305566295"
+      "templateHash": "12994816753619886228"
     }
   },
   "parameters": {
@@ -109,6 +109,13 @@
       "metadata": {
         "description": "The capacity of the model deployment in TPM."
       }
+    },
+    "modelQuota": {
+      "type": "int",
+      "defaultValue": 100,
+      "metadata": {
+        "description": "The quota to assign to the model deployment."
+      }
     }
   },
   "variables": {
@@ -165,6 +172,7 @@
         "name": "[parameters('modelSkuName')]"
       },
       "properties": {
+        "modelQuota": "[parameters('modelQuota')]",
         "model": {
           "name": "[parameters('modelName')]",
           "format": "[parameters('modelFormat')]",

--- a/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/main.bicep
@@ -61,6 +61,9 @@ param modelSkuName string = 'GlobalStandard'
 @description('The capacity of the model deployment in TPM.')
 param modelCapacity int = 40
 
+@description('The quota to assign to the model deployment.')
+param modelQuota int = 100
+
 resource account 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
   name: accountName
   location: location
@@ -117,6 +120,7 @@ resource modelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-
     name: modelSkuName
   }
   properties: {
+    modelQuota: modelQuota
     model:{
       name: modelName
       format: modelFormat


### PR DESCRIPTION
Updates the basic agent setup Bicep template to include `modelQuota` set to 100 on the model deployment.